### PR TITLE
PP 3.45, Chapter 4 file and PP 4.4

### DIFF
--- a/chapter_3.md
+++ b/chapter_3.md
@@ -19,7 +19,9 @@
     1. [Page 304, Practice Problem 3.41](#page-304-practice-problem-341)
         1. [Aside: How can you know?](#aside-how-can-you-know)
     1. [Page 305, Practice Problem 3.42](#page-305-practice-problem-342)
-    1. [Page 311, Practice Problem 3.44](#page-311-practice-problem-344) 
+    1. [Page 311, Practice Problem 3.44](#page-311-practice-problem-344)
+    1. [Page 311, Practice Problem 3.45](#page-311-practice-problem-345)
+   		1. [Aside: How can I verify this?](#aside-how-can-i-verify-this)
 
 <!-- vim-markdown-toc -->
 
@@ -260,3 +262,52 @@ packet-beta
 
 - Total size: 88 bytes (32 + 32 + 24)
 - Alignment requirement: 8 bytes
+
+### Page 311, Practice Problem 3.45
+
+The problem is with `short d`. Short requires a 2 byte alignment. There is no need to put it in byte 16; 14 is fine, since its divisible by 2. The book is adding extra unnecessary offset in the solution.
+
+| Field | Size | Offset
+| --- | --- | --- |
+| a | 8 | 0 |
+| b | 4 | 8 |
+| c | 1 | 12 |
+| **1 byte of padding needed here** | 1 | 13 |
+| d | 2 | 14 |
+| e | 8 | 16 | 
+| f | 8 | 24 |
+| g | 4 | 32 | 
+| h | 8 | 40 |
+
+- Total size: 48 bytes
+
+#### Aside: How can I verify this?
+You can verify this by running:
+
+```c
+#include <stdio.h>
+#include <stddef.h>
+
+struct rec // same struct that was given in the problem
+{
+    int *a; float b; char c; short d; 
+    long e; double f; int g; char *h;
+};
+
+int main() 
+{   
+    printf("Element:\t");
+    printf("a\tb\tc\td\te\tf\tg\th\n");
+
+    printf("Offset: \t");
+    printf("%zu\t", offsetof(struct rec, a));
+    printf("%zu\t", offsetof(struct rec, b));
+    printf("%zu\t", offsetof(struct rec, c));
+    printf("%zu\t", offsetof(struct rec, d));
+    printf("%zu\t", offsetof(struct rec, e));
+    printf("%zu\t", offsetof(struct rec, f));
+    printf("%zu\t", offsetof(struct rec, g));
+    printf("%zu\n", offsetof(struct rec, h));
+    return 0;
+}
+```

--- a/chapter_4.md
+++ b/chapter_4.md
@@ -25,7 +25,7 @@ long rsum(long *start, long count)
 rsum:
   xorq %rax,%rax      # Set return value to 0
   andq %rsi,o/orsi    # Set condition codes
-  je return           # If count == 0, return 0
+  jle return           # If count <= 0, return 0
   
   pushq rbx           # Save callee-saved register
   

--- a/chapter_4.md
+++ b/chapter_4.md
@@ -1,0 +1,66 @@
+1. [Section 4.1 The Y64-86 Instruction Set Architecture](#section-41-the-y6486-instruction-set-architecture)
+    1. [Page 406, Practice Problem 4.4](#page-406-practice-problem-44)
+
+## Section 4.1 The Y64-86 Instruction Set Architecture
+
+### Page 406, Practice Problem 4.4
+
+Global edition makes this problem *significantly* harder and if not only that, the solution for it is very wrong as well.
+
+The original problem statement (found in the north american edition) asked us to translate the following code:
+
+```c
+long rsum(long *start, long count)
+{
+    if (count <= 0)
+        return O;
+    return *Start + rsum(start + 1, count - 1);
+}
+```
+
+<details>
+<summary>Click here to reveal the solution for the north american edition</summary>
+
+```
+rsum:
+  xorq %rax,%rax      # Set return value to 0
+  andq %rsi,o/orsi    # Set condition codes
+  je return           # If count == 0, return 0
+  
+  pushq rbx           # Save callee-saved register
+  
+  mrmovq (%rdi),%rbx  # Get *start
+  irmovq $-1,%r10     
+  addq %r10,%rsi      # count--
+  irmovq $8,%r10      
+  addq %r10,%rdi      # start++
+  call rsum
+  addq %rbx,%rax      # Add *start to sum
+  popq %rbx           # Restore callee-saved ·register.
+
+return:
+  ret
+```
+
+</details>
+
+In the global edition, however, they changed a few things in this code that make it very complicated to solve.
+And for the solution, whoever made global edition basically copied from the north american one and changed the comments, without considering the modifications they made to the C snippet. They also used an instruction that doesn't even exist.
+
+Erratas in the global ed. solution:
+
+1. `xor %rax, $rax` sets %rax to $0$, not to $1$
+2. The checking doesnt match the condition in the C code
+3. For some reason it does the multiplication with `imulq`, this instruction doesn't even exist in Y64-86. To multiply we would have to use addq in a loop.
+
+Given that, in the global edition this problem is significantly harder, requiring us to implement a multiplication only using addition, while handling both negative and positive values of *start. I would recommend just solving the original problem.
+However, if you feel ambitious, and want to give the global edition problem a try, go ahead. And if you get it working, add your solution below. I will open an issue for it.
+
+<details>
+<summary>Solution for global edition</summary>
+
+```
+TO-DO: add solution to global ed. here 
+```
+
+</details>

--- a/chapter_4.md
+++ b/chapter_4.md
@@ -7,60 +7,18 @@
 
 Global edition makes this problem *significantly* harder and if not only that, the solution for it is very wrong as well.
 
-The original problem statement (found in the north american edition) asked us to translate the following code:
-
-```c
-long rsum(long *start, long count)
-{
-    if (count <= 0)
-        return O;
-    return *Start + rsum(start + 1, count - 1);
-}
-```
-
-<details>
-<summary>Click here to reveal the solution for the north american edition</summary>
-
-```
-rsum:
-  xorq %rax,%rax      # Set return value to 0
-  andq %rsi,o/orsi    # Set condition codes
-  jle return           # If count <= 0, return 0
-  
-  pushq rbx           # Save callee-saved register
-  
-  mrmovq (%rdi),%rbx  # Get *start
-  irmovq $-1,%r10     
-  addq %r10,%rsi      # count--
-  irmovq $8,%r10      
-  addq %r10,%rdi      # start++
-  call rsum
-  addq %rbx,%rax      # Add *start to sum
-  popq %rbx           # Restore callee-saved ·register.
-
-return:
-  ret
-```
-
-</details>
-
-In the global edition, however, they changed a few things in this code that make it very complicated to solve.
-And for the solution, whoever made global edition basically copied from the north american one and changed the comments, without considering the modifications they made to the C snippet. They also used an instruction that doesn't even exist.
-
 Erratas in the global ed. solution:
 
 1. `xor %rax, $rax` sets %rax to $0$, not to $1$
 2. The checking doesnt match the condition in the C code
 3. For some reason it does the multiplication with `imulq`, this instruction doesn't even exist in Y64-86. To multiply we would have to use addq in a loop.
 
-Given that, in the global edition this problem is significantly harder, requiring us to implement a multiplication only using addition, while handling both negative and positive values of *start. I would recommend just solving the original problem.
-However, if you feel ambitious, and want to give the global edition problem a try, go ahead. And if you get it working, add your solution below. I will open an issue for it.
+The main problem is with errata number 3. Since there are no multiplication instructions, we have to implement a multiplication only using addition. Shifting does not exist in Y64-86 so there is no way of using left shifts combined with addition or subtraction to implement multiplication. The only way of doing it is via repeated addition (an addition loop).
 
-<details>
-<summary>Solution for global edition</summary>
+What I would recommend doing is to simply change the multiplication (`*`) to an addition (`+`), and solve the modified problem. This aligns better with the original problem found in the NA edition.
 
-```
+However, if you feel ambitious, and want to give the global edition problem a try, go ahead. And if you get it working, you can delete this line and add your solution below. I opened an issue for it, so make sure to check the issues tab.
+
+```asm
 TO-DO: add solution to global ed. here 
 ```
-
-</details>


### PR DESCRIPTION
- Practice Problem 3.45, with proof of its correction.

In PP 4.4, the global edition changes make it quite hard to be solved. Also, there are a bunch of errors in the solution (they even used an instruction that doesn't even exist in y64-86).

I didn't feel like solving the global edition problem, but once this gets merged i will create an issue describing it, so maybe someone in the future adds a working solution. 